### PR TITLE
[update]お知らせの並び順の修正

### DIFF
--- a/src/components/api/notion/route.jsx
+++ b/src/components/api/notion/route.jsx
@@ -13,6 +13,6 @@ response.results.map((news) => {
     obj.color = news.properties.Category.select.color;
     obj.date = news.properties.Date.date.start;
     array__allNewsData.push(obj);
-});    
-
+});
+array__allNewsData.sort((a, b) => new Date(b.date) - new Date(a.date));
 export default array__allNewsData;


### PR DESCRIPTION
## 概要
お知らせの並び順に不具合があるので降順になるように修正する

## 関連Issue
https://github.com/zatty-5118/portfolio/issues/9

## 対応内容・変更内容

- 該当ファイルの調査

- 配列内の並び順を降順にする処理を追加

## レビュー観点

- [x] 想定通りに動作するか？
- [x] JS/TS/CSS/Reactの書き方は適切か？
- [x] 設計方法は適切か？
- [x] 他の部分と書き方・命名・ディレクトリ構成等が異なっていないか？
- [x] 関数、コンポーネントの命名方法は適切か？